### PR TITLE
Dev 0.3.3

### DIFF
--- a/muutils/json_serialize/array.py
+++ b/muutils/json_serialize/array.py
@@ -1,6 +1,6 @@
 import typing
 import warnings
-from typing import Any, Dict, Iterable, Literal, Optional, Sequence
+from typing import Any, Iterable, Literal, Optional, Sequence
 
 import numpy as np
 
@@ -21,10 +21,10 @@ def array_n_elements(arr) -> int:  # type: ignore[name-defined]
         raise TypeError(f"invalid type: {type(arr)}")
 
 
-def arr_metadata(arr) -> Dict[str, Any]:
+def arr_metadata(arr) -> dict[str, list[int]|str|int]:
     """get metadata for a numpy array"""
     return {
-        "shape": arr.shape,
+        "shape": list(arr.shape),
         "dtype": str(arr.dtype),
         "n_elements": array_n_elements(arr),
     }

--- a/muutils/json_serialize/array.py
+++ b/muutils/json_serialize/array.py
@@ -21,7 +21,7 @@ def array_n_elements(arr) -> int:  # type: ignore[name-defined]
         raise TypeError(f"invalid type: {type(arr)}")
 
 
-def arr_metadata(arr) -> dict[str, list[int]|str|int]:
+def arr_metadata(arr) -> dict[str, list[int] | str | int]:
     """get metadata for a numpy array"""
     return {
         "shape": list(arr.shape),

--- a/muutils/json_serialize/array.py
+++ b/muutils/json_serialize/array.py
@@ -8,7 +8,7 @@ from muutils.json_serialize.util import JSONitem
 
 # pylint: disable=unused-argument
 
-ArrayMode = Literal["list", "array_list_meta", "array_hex_meta", "external"]
+ArrayMode = Literal["list", "array_list_meta", "array_hex_meta", "external", "zero_dim"]
 
 
 def array_n_elements(arr) -> int:  # type: ignore[name-defined]
@@ -68,14 +68,19 @@ def serialize_array(
      - `KeyError` : if the array mode is not valid
     """
 
-    if len(arr.shape) == 0:
-        return arr.item()
-
     if array_mode is None:
         array_mode = jser.array_mode
 
     arr_type: str = f"{type(arr).__module__}.{type(arr).__name__}"
     arr_np: np.ndarray = arr if isinstance(arr, np.ndarray) else np.array(arr)
+
+    # handle zero-dimensional arrays
+    if len(arr.shape) == 0:
+        return {
+            "__format__": f"{arr_type}:zero_dim",
+            "data": arr.item(),
+            **arr_metadata(arr),
+        }
 
     if array_mode == "array_list_meta":
         return {
@@ -112,6 +117,8 @@ def infer_array_mode(arr: JSONitem) -> ArrayMode:
             return "array_hex_meta"
         elif fmt.endswith(":external"):
             return "external"
+        elif fmt.endswith(":zero_dim"):
+            return "zero_dim"
         else:
             raise ValueError(f"invalid format: {arr}")
     elif isinstance(arr, list):
@@ -164,5 +171,11 @@ def load_array(arr: JSONitem, array_mode: Optional[ArrayMode] = None) -> Any:
         # assume ZANJ has taken care of it
         assert isinstance(arr, typing.Mapping)
         return arr["data"]
+    elif array_mode == "zero_dim":
+        assert isinstance(arr, typing.Mapping)
+        data = np.array(arr["data"])
+        if tuple(arr["shape"]) != tuple(data.shape):
+            raise ValueError(f"invalid shape: {arr}")
+        return data
     else:
         raise ValueError(f"invalid array_mode: {array_mode}")

--- a/muutils/json_serialize/json_serialize.py
+++ b/muutils/json_serialize/json_serialize.py
@@ -15,6 +15,7 @@ from muutils.json_serialize.util import (
     _recursive_hashify,
     isinstance_namedtuple,
     safe_getsource,
+    string_as_lines,
     try_catch,
 )
 
@@ -71,12 +72,12 @@ class SerializerHandler:
             # get the code and doc of the check function
             "check": {
                 "code": safe_getsource(self.check),
-                "doc": self.check.__doc__,
+                "doc": string_as_lines(self.check.__doc__),
             },
             # get the code and doc of the load function
             "serialize_func": {
                 "code": safe_getsource(self.serialize_func),
-                "doc": self.serialize_func.__doc__,
+                "doc": string_as_lines(self.serialize_func.__doc__),
             },
             # get the uid, source_pckg, priority, and desc
             "uid": str(self.uid),

--- a/muutils/tensor_utils.py
+++ b/muutils/tensor_utils.py
@@ -165,6 +165,14 @@ ATensor = jaxtype_factory("ATensor", torch.Tensor, jaxtyping.Float)  # type: ign
 NDArray = jaxtype_factory("NDArray", np.ndarray, jaxtyping.Float)  # type: ignore[misc, assignment]
 
 
+def numpy_to_torch_dtype(dtype: np.dtype|torch.dtype) -> torch.dtype:
+    """convert numpy dtype to torch dtype"""
+    if isinstance(dtype, torch.dtype):
+        return dtype
+    else:
+        return torch.from_numpy(np.array(0, dtype=dtype)).dtype
+
+
 DTYPE_LIST: list = [
     *[
         bool,
@@ -233,6 +241,11 @@ DTYPE_MAP: dict = {
         for dtype in DTYPE_LIST
         if dtype.__module__ == "numpy"
     },
+}
+
+TORCH_DTYPE_MAP: dict = {
+    key : numpy_to_torch_dtype(dtype)
+    for key, dtype in DTYPE_MAP.items()
 }
 
 

--- a/muutils/tensor_utils.py
+++ b/muutils/tensor_utils.py
@@ -226,7 +226,14 @@ DTYPE_LIST: list = [
     ],
 ]
 
-DTYPE_MAP: dict = {str(x): x for x in DTYPE_LIST}
+DTYPE_MAP: dict = {
+    **{str(x): x for x in DTYPE_LIST},
+    **{
+        dtype.__name__: dtype
+        for dtype in DTYPE_LIST
+        if dtype.__module__ == "numpy"
+    },
+}
 
 
 TORCH_OPTIMIZERS_MAP: dict[str, typing.Type[torch.optim.Optimizer]] = {

--- a/muutils/tensor_utils.py
+++ b/muutils/tensor_utils.py
@@ -336,3 +336,15 @@ def rpad_array(
 ) -> np.ndarray:
     """pad a 1-d array on the right with pad_value to length `pad_length`"""
     return pad_array(array, pad_length, pad_value, rpad=True)
+
+
+def compare_state_dicts(d1: dict, d2: dict):
+    assert d1.keys() == d2.keys(), "state dict keys don't match!"
+    keys_failed: list[str] = list()
+    for k, v in d1.items():
+        v_load = d2[k]
+        if not (v == v_load).all():
+            keys_failed.append(k)
+    assert (
+        len(keys_failed) == 0
+    ), f"{len(keys_failed)} / {len(d1)} state dict elements don't match: {keys_failed}"

--- a/muutils/tensor_utils.py
+++ b/muutils/tensor_utils.py
@@ -165,7 +165,7 @@ ATensor = jaxtype_factory("ATensor", torch.Tensor, jaxtyping.Float)  # type: ign
 NDArray = jaxtype_factory("NDArray", np.ndarray, jaxtyping.Float)  # type: ignore[misc, assignment]
 
 
-def numpy_to_torch_dtype(dtype: np.dtype|torch.dtype) -> torch.dtype:
+def numpy_to_torch_dtype(dtype: np.dtype | torch.dtype) -> torch.dtype:
     """convert numpy dtype to torch dtype"""
     if isinstance(dtype, torch.dtype):
         return dtype
@@ -236,16 +236,11 @@ DTYPE_LIST: list = [
 
 DTYPE_MAP: dict = {
     **{str(x): x for x in DTYPE_LIST},
-    **{
-        dtype.__name__: dtype
-        for dtype in DTYPE_LIST
-        if dtype.__module__ == "numpy"
-    },
+    **{dtype.__name__: dtype for dtype in DTYPE_LIST if dtype.__module__ == "numpy"},
 }
 
 TORCH_DTYPE_MAP: dict = {
-    key : numpy_to_torch_dtype(dtype)
-    for key, dtype in DTYPE_MAP.items()
+    key: numpy_to_torch_dtype(dtype) for key, dtype in DTYPE_MAP.items()
 }
 
 

--- a/muutils/zanj/loading.py
+++ b/muutils/zanj/loading.py
@@ -12,7 +12,13 @@ import torch
 
 from muutils.json_serialize.array import load_array
 from muutils.json_serialize.json_serialize import ObjectPath
-from muutils.json_serialize.util import ErrorMode, JSONdict, JSONitem, safe_getsource, string_as_lines
+from muutils.json_serialize.util import (
+    ErrorMode,
+    JSONdict,
+    JSONitem,
+    safe_getsource,
+    string_as_lines,
+)
 from muutils.tensor_utils import DTYPE_MAP, TORCH_DTYPE_MAP
 from muutils.zanj.externals import (
     GET_EXTERNAL_LOAD_FUNC,

--- a/muutils/zanj/loading.py
+++ b/muutils/zanj/loading.py
@@ -12,7 +12,7 @@ import torch
 
 from muutils.json_serialize.array import load_array
 from muutils.json_serialize.json_serialize import ObjectPath
-from muutils.json_serialize.util import ErrorMode, JSONdict, JSONitem, safe_getsource
+from muutils.json_serialize.util import ErrorMode, JSONdict, JSONitem, safe_getsource, string_as_lines
 from muutils.tensor_utils import DTYPE_MAP, TORCH_DTYPE_MAP
 from muutils.zanj.externals import (
     GET_EXTERNAL_LOAD_FUNC,
@@ -51,12 +51,12 @@ class LoaderHandler:
             # get the code and doc of the check function
             "check": {
                 "code": safe_getsource(self.check),
-                "doc": self.check.__doc__,
+                "doc": string_as_lines(self.check.__doc__),
             },
             # get the code and doc of the load function
             "load": {
                 "code": safe_getsource(self.load),
-                "doc": self.load.__doc__,
+                "doc": string_as_lines(self.load.__doc__),
             },
             # get the uid, source_pckg, priority, and desc
             "uid": str(self.uid),

--- a/muutils/zanj/loading.py
+++ b/muutils/zanj/loading.py
@@ -10,10 +10,10 @@ import numpy as np
 import pandas as pd
 import torch
 
-from muutils.tensor_utils import DTYPE_MAP, TORCH_DTYPE_MAP
 from muutils.json_serialize.array import load_array
 from muutils.json_serialize.json_serialize import ObjectPath
 from muutils.json_serialize.util import ErrorMode, JSONdict, JSONitem, safe_getsource
+from muutils.tensor_utils import DTYPE_MAP, TORCH_DTYPE_MAP
 from muutils.zanj.externals import (
     GET_EXTERNAL_LOAD_FUNC,
     ZANJ_MAIN,

--- a/muutils/zanj/loading.py
+++ b/muutils/zanj/loading.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 import torch
 
-from muutils.tensor_utils import DTYPE_MAP
+from muutils.tensor_utils import DTYPE_MAP, TORCH_DTYPE_MAP
 from muutils.json_serialize.array import load_array
 from muutils.json_serialize.json_serialize import ObjectPath
 from muutils.json_serialize.util import ErrorMode, JSONdict, JSONitem, safe_getsource
@@ -115,7 +115,7 @@ LOADER_MAP: dict[str, LoaderHandler] = {
                 # and json_item["data"].dtype.name == json_item["dtype"]
                 # and tuple(json_item["data"].shape) == tuple(json_item["shape"])
             ),
-            load=lambda json_item, path=None, z=None: torch.tensor(load_array(json_item), dtype=DTYPE_MAP[json_item["dtype"]]),  # type: ignore[misc]
+            load=lambda json_item, path=None, z=None: torch.tensor(load_array(json_item), dtype=TORCH_DTYPE_MAP[json_item["dtype"]]),  # type: ignore[misc]
             uid="torch.Tensor",
             source_pckg="muutils.zanj",
             desc="torch.Tensor loader",

--- a/muutils/zanj/loading.py
+++ b/muutils/zanj/loading.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 import torch
 
+from muutils.tensor_utils import DTYPE_MAP
 from muutils.json_serialize.array import load_array
 from muutils.json_serialize.json_serialize import ObjectPath
 from muutils.json_serialize.util import ErrorMode, JSONdict, JSONitem, safe_getsource
@@ -101,7 +102,7 @@ LOADER_MAP: dict[str, LoaderHandler] = {
                 # and json_item["data"].dtype.name == json_item["dtype"]
                 # and tuple(json_item["data"].shape) == tuple(json_item["shape"])
             ),
-            load=lambda json_item, path=None, z=None: np.array(load_array(json_item)),  # type: ignore[misc]
+            load=lambda json_item, path=None, z=None: np.array(load_array(json_item), dtype=DTYPE_MAP[json_item["dtype"]]),  # type: ignore[misc]
             uid="numpy.ndarray",
             source_pckg="muutils.zanj",
             desc="numpy.ndarray loader",
@@ -114,7 +115,7 @@ LOADER_MAP: dict[str, LoaderHandler] = {
                 # and json_item["data"].dtype.name == json_item["dtype"]
                 # and tuple(json_item["data"].shape) == tuple(json_item["shape"])
             ),
-            load=lambda json_item, path=None, z=None: torch.tensor(load_array(json_item)),  # type: ignore[misc]
+            load=lambda json_item, path=None, z=None: torch.tensor(load_array(json_item), dtype=DTYPE_MAP[json_item["dtype"]]),  # type: ignore[misc]
             uid="torch.Tensor",
             source_pckg="muutils.zanj",
             desc="torch.Tensor loader",

--- a/muutils/zanj/readme.md
+++ b/muutils/zanj/readme.md
@@ -33,3 +33,33 @@ contains some configuration info about saving, such as:
 - error modes
 - handlers for serialization
 
+
+# Comparison to other formats
+
+
+
+| Format                  | Safe | Zero-copy | Lazy loading | No file size limit | Layout control | Flexibility | Bfloat16 |
+| ----------------------- | ---- | --------- | ------------ | ------------------ | -------------- | ----------- | -------- |
+| pickle (PyTorch)        | ❌   | ❌        | ❌           | ✅                 | ❌             | ✅          | ✅       |
+| H5 (Tensorflow)         | ✅   | ❌        | ✅           | ✅                 | ~              | ~           | ❌       |
+| HDF5                    | ✅   | ?         | ✅           | ✅                 | ~              | ✅          | ❌       |
+| SavedModel (Tensorflow) | ✅   | ❌        | ❌           | ✅                 | ✅             | ❌          | ✅       |
+| MsgPack (flax)          | ✅   | ✅        | ❌           | ✅                 | ❌             | ❌          | ✅       |
+| Protobuf (ONNX)         | ✅   | ❌        | ❌           | ❌                 | ❌             | ❌          | ✅       |
+| Cap'n'Proto             | ✅   | ✅        | ~            | ✅                 | ✅             | ~           | ❌       |
+| Numpy (npy,npz)         | ✅   | ?         | ?            | ❌                 | ✅             | ❌          | ❌       |
+| SafeTensors             | ✅   | ✅        | ✅           | ✅                 | ✅             | ❌          | ✅       |
+| exdir                   | ✅   | ?         | ?            | ?                  | ?              | ✅          | ❌       |
+| ZANJ                    | ✅   | ?         | ❌*          | ✅                 | ✅             | ✅          | ❌       |
+
+
+- Safe: Can I use a file randomly downloaded and expect not to run arbitrary code ?
+- Zero-copy: Does reading the file require more memory than the original file ?
+- Lazy loading: Can I inspect the file without loading everything ? And loading only some tensors in it without scanning the whole file (distributed setting) ?
+- Layout control: Lazy loading, is not necessarily enough since if the information about tensors is spread out in your file, then even if the information is lazily accessible you might have to access most of your file to read the available tensors (incurring many DISK -> RAM copies). Controlling the layout to keep fast access to single tensors is important.
+- No file size limit: Is there a limit to the file size ?
+- Flexibility: Can I save custom code in the format and be able to use it later with zero extra code ? (~ means we can store more than pure tensors, but no custom code)
+- Bfloat16: Does the format support native bfloat16 (meaning no weird workarounds are necessary)? This is becoming increasingly important in the ML world.
+
+
+(This table was Stolen from [safetensors](https://github.com/huggingface/safetensors/blob/main/README.md))

--- a/muutils/zanj/serializing.py
+++ b/muutils/zanj/serializing.py
@@ -143,7 +143,8 @@ def zanj_external_serialize(
         else:
             raise TypeError(f"expected list or pd.DataFrame, got {type(data)}")
 
-        output.update(jsonl_metadata(data_new))
+        if all([isinstance(item, dict) for item in data_new]):
+            output.update(jsonl_metadata(data_new))
 
     # store the item for external serialization
     jser._externals[archive_path] = ExternalItem(

--- a/muutils/zanj/torchutil.py
+++ b/muutils/zanj/torchutil.py
@@ -6,7 +6,7 @@ import torch
 
 from muutils.json_serialize import SerializableDataclass
 from muutils.json_serialize.json_serialize import ObjectPath
-from muutils.json_serialize.util import string_as_lines
+from muutils.json_serialize.util import safe_getsource, string_as_lines
 from muutils.zanj import ZANJ, register_loader_handler
 from muutils.zanj.loading import LoaderHandler, load_item_recursive
 
@@ -88,7 +88,8 @@ class ConfiguredModel(
             config=self.config.serialize(),
             meta=dict(
                 class_name=self.__class__.__name__,
-                class_doc=self.__class__.__doc__,
+                class_doc=string_as_lines(self.__class__.__doc__),
+                class_source=safe_getsource(self.__class__),
                 module_name=self.__class__.__module__,
                 module_mro=[str(x) for x in self.__class__.__mro__],
                 num_params=num_params(self),

--- a/muutils/zanj/torchutil.py
+++ b/muutils/zanj/torchutil.py
@@ -64,7 +64,7 @@ class ConfiguredModel(
     """
 
     # dont set this directly, use `set_config_class()` decorator
-    _config_class: type | None = None 
+    _config_class: type | None = None
     zanj_config_class = property(lambda self: type(self)._config_class)
 
     def __init__(self, zanj_model_config: T_config, **kwargs):

--- a/muutils/zanj/torchutil.py
+++ b/muutils/zanj/torchutil.py
@@ -64,18 +64,18 @@ class ConfiguredModel(
     """
 
     _config_class: type | None = None
-    config_class = property(lambda self: type(self)._config_class)
+    zanj_config_class = property(lambda self: type(self)._config_class)
 
-    def __init__(self, config: T_config):
-        super().__init__()
-        if self.config_class is None:
+    def __init__(self, zanj_model_config: T_config, **kwargs):
+        super().__init__(**kwargs)
+        if self.zanj_config_class is None:
             raise NotImplementedError("you need to set `config_class` for your model")
-        if not isinstance(config, self.config_class):  # type: ignore
+        if not isinstance(zanj_model_config, self.zanj_config_class):  # type: ignore
             raise TypeError(
-                f"config must be an instance of {self.config_class = }, got {type(config) = }"
+                f"config must be an instance of {self.zanj_config_class = }, got {type(zanj_model_config) = }"
             )
 
-        self.config: T_config = config
+        self.config: T_config = zanj_model_config
 
     def serialize(
         self, path: ObjectPath = tuple(), zanj: ZANJ | None = None

--- a/muutils/zanj/torchutil.py
+++ b/muutils/zanj/torchutil.py
@@ -98,6 +98,11 @@ class ConfiguredModel(
         )
         return obj
 
+    def save(self, file_path: str, zanj: ZANJ | None = None):
+        if zanj is None:
+            zanj = ZANJ()
+        zanj.save(self, file_path)
+
     @classmethod
     def load(
         cls, obj: dict[str, Any], path: ObjectPath, zanj: ZANJ | None = None

--- a/muutils/zanj/torchutil.py
+++ b/muutils/zanj/torchutil.py
@@ -63,7 +63,8 @@ class ConfiguredModel(
     `super().__init__(config)`
     """
 
-    _config_class: type | None = None
+    # dont set this directly, use `set_config_class()` decorator
+    _config_class: type | None = None 
     zanj_config_class = property(lambda self: type(self)._config_class)
 
     def __init__(self, zanj_model_config: T_config, **kwargs):
@@ -90,6 +91,7 @@ class ConfiguredModel(
                 module_name=self.__class__.__module__,
                 module_mro=[str(x) for x in self.__class__.__mro__],
                 num_params=num_params(self),
+                as_str=str(self),
             ),
             state_dict=self.state_dict(),
             __format__=self.__class__.__name__,

--- a/muutils/zanj/zanj.py
+++ b/muutils/zanj/zanj.py
@@ -93,7 +93,7 @@ class ZANJ(JsonSerializer):
         # create the externals, leave it empty
         self._externals: dict[str, ExternalItem] = dict()
 
-    def externals_info(self) -> dict[str, dict]:
+    def externals_info(self) -> dict[str, dict[str, str|int|list[int]]]:
         """return information about the current externals"""
         output: dict[str, dict] = dict()
 
@@ -117,28 +117,25 @@ class ZANJ(JsonSerializer):
 
     def meta(self) -> JSONitem:
         """return the metadata of the ZANJ archive"""
-        global LOADER_MAP
 
         serialization_handlers = {h.uid: h.serialize() for h in self.handlers}
         load_handlers = {h.uid: h.serialize() for h in LOADER_MAP.values()}
 
-        return json_serialize(
-            dict(
-                # configuration of this ZANJ instance
-                zanj_cfg=dict(
-                    error_mode=str(self.error_mode),
-                    array_mode=str(self.array_mode),
-                    external_array_threshold=self.external_array_threshold,
-                    external_table_threshold=self.external_table_threshold,
-                    compress=self.compress,
-                    serialization_handlers=serialization_handlers,
-                    load_handlers=load_handlers,
-                ),
-                # system info (python, pip packages, torch & cuda, platform info, git info)
-                sysinfo=SysInfo.get_all(include=("python", "pytorch")),
-                externals_info=self.externals_info(),
-                timestamp=time.time(),
-            )
+        return dict(
+            # configuration of this ZANJ instance
+            zanj_cfg=dict(
+                error_mode=str(self.error_mode),
+                array_mode=str(self.array_mode),
+                external_array_threshold=self.external_array_threshold,
+                external_table_threshold=self.external_table_threshold,
+                compress=self.compress,
+                serialization_handlers=serialization_handlers,
+                load_handlers=load_handlers,
+            ),
+            # system info (python, pip packages, torch & cuda, platform info, git info)
+            sysinfo=json_serialize(SysInfo.get_all(include=("python", "pytorch"))),
+            externals_info=self.externals_info(),
+            timestamp=time.time(),
         )
 
     def save(self, obj: Any, file_path: str | Path) -> str:

--- a/muutils/zanj/zanj.py
+++ b/muutils/zanj/zanj.py
@@ -93,7 +93,7 @@ class ZANJ(JsonSerializer):
         # create the externals, leave it empty
         self._externals: dict[str, ExternalItem] = dict()
 
-    def externals_info(self) -> dict[str, dict[str, str|int|list[int]]]:
+    def externals_info(self) -> dict[str, dict[str, str | int | list[int]]]:
         """return information about the current externals"""
         output: dict[str, dict] = dict()
 

--- a/tests/test_zanj_torch.py
+++ b/tests/test_zanj_torch.py
@@ -7,23 +7,12 @@ from muutils.json_serialize import (
     serializable_dataclass,
     serializable_field,
 )
+from muutils.tensor_utils import compare_state_dicts
 from muutils.zanj import ZANJ
 
 np.random.seed(0)
 
 TEST_DATA_PATH: Path = Path("tests/junk_data")
-
-
-def compare_state_dicts(d1: dict, d2: dict):
-    assert d1.keys() == d2.keys(), "state dict keys don't match!"
-    keys_failed: list[str] = list()
-    for k, v in d1.items():
-        v_load = d2[k]
-        if not (v == v_load).all():
-            keys_failed.append(k)
-    assert (
-        len(keys_failed) == 0
-    ), f"{len(keys_failed)} / {len(d1)} state dict elements don't match: {keys_failed}"
 
 
 def test_torch_configmodel():

--- a/tests/test_zanj_torch.py
+++ b/tests/test_zanj_torch.py
@@ -14,6 +14,16 @@ np.random.seed(0)
 TEST_DATA_PATH: Path = Path("tests/junk_data")
 
 
+def compare_state_dicts(d1: dict, d2: dict):
+    assert d1.keys() == d2.keys(), "state dict keys don't match!"
+    keys_failed: list[str] = list()
+    for k, v in d1.items():
+        v_load = d2[k]
+        if not (v == v_load).all():
+            keys_failed.append(k)
+    assert len(keys_failed) == 0, f"{len(keys_failed)} / {len(d1.state_dict)} state dict elements don't match: {keys_failed}"
+
+
 def test_torch_configmodel():
     import torch
 
@@ -96,8 +106,7 @@ def test_torch_configmodel():
 
     assert model.config == model2.config
 
-    for k, v in model.state_dict().items():
-        assert torch.allclose(model.state_dict()[k], model2.state_dict()[k])
+    compare_state_dicts(model.state_dict(), model2.state_dict())
 
     model3: MyGPT = ZANJ().read(fname)
     print(f"loaded model from {fname}")
@@ -105,5 +114,4 @@ def test_torch_configmodel():
 
     assert model.config == model3.config
 
-    for k, v in model.state_dict().items():
-        assert torch.allclose(model.state_dict()[k], model3.state_dict()[k])
+    compare_state_dicts(model.state_dict(), model3.state_dict())

--- a/tests/test_zanj_torch.py
+++ b/tests/test_zanj_torch.py
@@ -21,7 +21,9 @@ def compare_state_dicts(d1: dict, d2: dict):
         v_load = d2[k]
         if not (v == v_load).all():
             keys_failed.append(k)
-    assert len(keys_failed) == 0, f"{len(keys_failed)} / {len(d1.state_dict)} state dict elements don't match: {keys_failed}"
+    assert (
+        len(keys_failed) == 0
+    ), f"{len(keys_failed)} / {len(d1.state_dict)} state dict elements don't match: {keys_failed}"
 
 
 def test_torch_configmodel():

--- a/tests/test_zanj_torch.py
+++ b/tests/test_zanj_torch.py
@@ -23,7 +23,7 @@ def compare_state_dicts(d1: dict, d2: dict):
             keys_failed.append(k)
     assert (
         len(keys_failed) == 0
-    ), f"{len(keys_failed)} / {len(d1.state_dict)} state dict elements don't match: {keys_failed}"
+    ), f"{len(keys_failed)} / {len(d1)} state dict elements don't match: {keys_failed}"
 
 
 def test_torch_configmodel():


### PR DESCRIPTION
- updates to `ConfiguredModel` interface
- fixes to how ZANJ stores metadata
- fixed bug with `list:external` serialize mode, it previously only worked for a list of dicts
- added `compare_state_dict` for testing things