### PR TITLE
Dev 0.3.7

### DIFF
--- a/muutils/zanj/torchutil.py
+++ b/muutils/zanj/torchutil.py
@@ -190,19 +190,32 @@ def set_config_class(
 
     return wrapper
 
+class ConfigMismatchException(ValueError):
+    def __init__(self, msg: str, diff):
+        super().__init__(msg)
+        self.diff = diff
+
+    def __str__(self):
+        return f"{super().__str__()}: {self.diff}"
 
 def assert_model_cfg_equality(model_a: ConfiguredModel, model_b: ConfiguredModel):
-    """check both models are correct instances and have the same config"""
-    assert isinstance(model_a, ConfiguredModel)
-    assert isinstance(model_a.zanj_model_config, SerializableDataclass)
-    assert isinstance(model_b, ConfiguredModel)
-    assert isinstance(model_b.zanj_model_config, SerializableDataclass)
+    """check both models are correct instances and have the same config
+    
+    Raises:
+        ConfigMismatchException: if the configs don't match, e.diff will contain the diff
+    """
+    assert isinstance(model_a, ConfiguredModel), "model_a must be a ConfiguredModel"
+    assert isinstance(model_a.zanj_model_config, SerializableDataclass), "model_a must have a zanj_model_config"
+    assert isinstance(model_b, ConfiguredModel), "model_b must be a ConfiguredModel"
+    assert isinstance(model_b.zanj_model_config, SerializableDataclass), "model_b must have a zanj_model_config"
 
     cls_type: type = type(model_a.zanj_model_config)
 
-    assert (
-        model_a.zanj_model_config == model_b.zanj_model_config
-    ), f"configs don't match: {cls_type.diff(model_a.zanj_model_config, model_b.zanj_model_config)}"
+    if not (model_a.zanj_model_config == model_b.zanj_model_config):
+        raise ConfigMismatchException(
+            f"configs of type {type(model_a.zanj_model_config)}, {type(model_b.zanj_model_config)} don't match",
+            diff = cls_type.diff(model_a.zanj_model_config, model_b.zanj_model_config),
+        )
 
 
 def assert_model_exact_equality(model_a: ConfiguredModel, model_b: ConfiguredModel):

--- a/muutils/zanj/torchutil.py
+++ b/muutils/zanj/torchutil.py
@@ -190,6 +190,7 @@ def set_config_class(
 
     return wrapper
 
+
 class ConfigMismatchException(ValueError):
     def __init__(self, msg: str, diff):
         super().__init__(msg)
@@ -198,23 +199,28 @@ class ConfigMismatchException(ValueError):
     def __str__(self):
         return f"{super().__str__()}: {self.diff}"
 
+
 def assert_model_cfg_equality(model_a: ConfiguredModel, model_b: ConfiguredModel):
     """check both models are correct instances and have the same config
-    
+
     Raises:
         ConfigMismatchException: if the configs don't match, e.diff will contain the diff
     """
     assert isinstance(model_a, ConfiguredModel), "model_a must be a ConfiguredModel"
-    assert isinstance(model_a.zanj_model_config, SerializableDataclass), "model_a must have a zanj_model_config"
+    assert isinstance(
+        model_a.zanj_model_config, SerializableDataclass
+    ), "model_a must have a zanj_model_config"
     assert isinstance(model_b, ConfiguredModel), "model_b must be a ConfiguredModel"
-    assert isinstance(model_b.zanj_model_config, SerializableDataclass), "model_b must have a zanj_model_config"
+    assert isinstance(
+        model_b.zanj_model_config, SerializableDataclass
+    ), "model_b must have a zanj_model_config"
 
     cls_type: type = type(model_a.zanj_model_config)
 
     if not (model_a.zanj_model_config == model_b.zanj_model_config):
         raise ConfigMismatchException(
             f"configs of type {type(model_a.zanj_model_config)}, {type(model_b.zanj_model_config)} don't match",
-            diff = cls_type.diff(model_a.zanj_model_config, model_b.zanj_model_config),
+            diff=cls_type.diff(model_a.zanj_model_config, model_b.zanj_model_config),
         )
 
 

--- a/tests/zanj/test_zanj_torch_cfgmismatch.py
+++ b/tests/zanj/test_zanj_torch_cfgmismatch.py
@@ -1,147 +1,159 @@
 from typing import Any
-from dataclasses import dataclass
-from pathlib import Path
 
-import numpy as np
+import torch
 
 from muutils.json_serialize import (
     SerializableDataclass,
     serializable_dataclass,
     serializable_field,
 )
-from muutils.tensor_utils import compare_state_dicts
-from muutils.zanj import ZANJ
-import torch
-from muutils.zanj.torchutil import ConfiguredModel, set_config_class, ConfigMismatchException, assert_model_cfg_equality
+from muutils.zanj.torchutil import (
+    ConfigMismatchException,
+    ConfiguredModel,
+    assert_model_cfg_equality,
+    set_config_class,
+)
 
 # Assuming required imports and classes are present (including ConfiguredModel, MyGPTConfig, and MyGPT)
 
 
 @serializable_dataclass
 class MyGPTConfig(SerializableDataclass):
-	"""basic test GPT config"""
+    """basic test GPT config"""
 
-	n_layers: int
-	n_heads: int
-	embedding_size: int
-	n_positions: int
-	n_vocab: int
-	junk_data: Any = serializable_field(default_factory=dict)
+    n_layers: int
+    n_heads: int
+    embedding_size: int
+    n_positions: int
+    n_vocab: int
+    junk_data: Any = serializable_field(default_factory=dict)
 
 
 @set_config_class(MyGPTConfig)
 class MyGPT(ConfiguredModel[MyGPTConfig]):
-	"""basic "GPT" model"""
+    """basic "GPT" model"""
 
-	def __init__(self, config: MyGPTConfig):
-		super().__init__(config)
-		self.transformer = torch.nn.Linear(config.embedding_size, config.n_vocab)
+    def __init__(self, config: MyGPTConfig):
+        super().__init__(config)
+        self.transformer = torch.nn.Linear(config.embedding_size, config.n_vocab)
 
-	def forward(self, x):
-		return self.transformer(x)
+    def forward(self, x):
+        return self.transformer(x)
 
 
 def test_config_mismatch_exception_direct():
-	msg = "Configs don't match"
-	diff = {"model_cfg": {"are_weights_processed": {"self": False, "other": True}}}
+    msg = "Configs don't match"
+    diff = {"model_cfg": {"are_weights_processed": {"self": False, "other": True}}}
 
-	exc = ConfigMismatchException(msg, diff)
-	assert exc.diff == diff
-	assert str(exc) == r"Configs don't match: {'model_cfg': {'are_weights_processed': {'self': False, 'other': True}}}"
+    exc = ConfigMismatchException(msg, diff)
+    assert exc.diff == diff
+    assert (
+        str(exc)
+        == r"Configs don't match: {'model_cfg': {'are_weights_processed': {'self': False, 'other': True}}}"
+    )
 
 
 def test_equal_configs():
-	config = MyGPTConfig(
-		n_layers=2,
-		n_heads=2,
-		embedding_size=16,
-		n_positions=16,
-		n_vocab=128,
-		junk_data = {"a": 1, "b": 2},
-	)
+    config = MyGPTConfig(
+        n_layers=2,
+        n_heads=2,
+        embedding_size=16,
+        n_positions=16,
+        n_vocab=128,
+        junk_data={"a": 1, "b": 2},
+    )
 
-	model_a = MyGPT(config)
-	model_b = MyGPT(config)
+    model_a = MyGPT(config)
+    model_b = MyGPT(config)
 
-	assert_model_cfg_equality(model_a, model_b)
+    assert_model_cfg_equality(model_a, model_b)
+
 
 def test_unequal_configs():
-	config_a = MyGPTConfig(
-		n_layers=2,
-		n_heads=2,
-		embedding_size=16,
-		n_positions=16,
-		n_vocab=128,
-		junk_data = {"a": 1, "b": 2},
-	)
-	# a different config
-	config_b = MyGPTConfig(
-		n_layers=3,
-		n_heads=2,
-		embedding_size=16,
-		n_positions=16,
-		n_vocab=128,
-		junk_data = {"a": 7, "something": "or other"},
-	)
+    config_a = MyGPTConfig(
+        n_layers=2,
+        n_heads=2,
+        embedding_size=16,
+        n_positions=16,
+        n_vocab=128,
+        junk_data={"a": 1, "b": 2},
+    )
+    # a different config
+    config_b = MyGPTConfig(
+        n_layers=3,
+        n_heads=2,
+        embedding_size=16,
+        n_positions=16,
+        n_vocab=128,
+        junk_data={"a": 7, "something": "or other"},
+    )
 
-	model_a = MyGPT(config_a)
-	model_b = MyGPT(config_b)
+    model_a = MyGPT(config_a)
+    model_b = MyGPT(config_b)
 
-	try:
-		assert_model_cfg_equality(model_a, model_b)
-	except ConfigMismatchException as exc:
-		assert exc.diff == {
-				"n_layers": {"self": 2, "other": 3},
-				"junk_data": {"self": {"a": 1, "b": 2}, "other": {"a": 7, "something": "or other"}},
-			}
-	else:
-		raise AssertionError("Expected a ConfigMismatchException!")
+    try:
+        assert_model_cfg_equality(model_a, model_b)
+    except ConfigMismatchException as exc:
+        assert exc.diff == {
+            "n_layers": {"self": 2, "other": 3},
+            "junk_data": {
+                "self": {"a": 1, "b": 2},
+                "other": {"a": 7, "something": "or other"},
+            },
+        }
+    else:
+        raise AssertionError("Expected a ConfigMismatchException!")
+
 
 def test_unequal_configs_2():
-	config_a = MyGPTConfig(
-		n_layers=2,
-		n_heads=2,
-		embedding_size=16,
-		n_positions=16,
-		n_vocab=128,
-		junk_data = {"a": 1, "b": 2},
-	)
-	# a different config
-	config_b = MyGPTConfig(
-		n_layers=3,
-		n_heads=2,
-		embedding_size=16,
-		n_positions=16,
-		n_vocab=128,
-		junk_data = "this isnt even a dict lol",
-	)
+    config_a = MyGPTConfig(
+        n_layers=2,
+        n_heads=2,
+        embedding_size=16,
+        n_positions=16,
+        n_vocab=128,
+        junk_data={"a": 1, "b": 2},
+    )
+    # a different config
+    config_b = MyGPTConfig(
+        n_layers=3,
+        n_heads=2,
+        embedding_size=16,
+        n_positions=16,
+        n_vocab=128,
+        junk_data="this isnt even a dict lol",
+    )
 
-	model_a = MyGPT(config_a)
-	model_b = MyGPT(config_b)
+    model_a = MyGPT(config_a)
+    model_b = MyGPT(config_b)
 
-	try:
-		assert_model_cfg_equality(model_a, model_b)
-	except ConfigMismatchException as exc:
-		assert exc.diff == {
-				"n_layers": {"self": 2, "other": 3},
-				"junk_data": {"self": {"a": 1, "b": 2}, "other": "this isnt even a dict lol"},
-			}
-	else:
-		raise AssertionError("Expected a ConfigMismatchException!")
+    try:
+        assert_model_cfg_equality(model_a, model_b)
+    except ConfigMismatchException as exc:
+        assert exc.diff == {
+            "n_layers": {"self": 2, "other": 3},
+            "junk_data": {
+                "self": {"a": 1, "b": 2},
+                "other": "this isnt even a dict lol",
+            },
+        }
+    else:
+        raise AssertionError("Expected a ConfigMismatchException!")
+
 
 def test_incorrect_instance():
-	config = MyGPTConfig(
-		n_layers=2,
-		n_heads=2,
-		embedding_size=16,
-		n_positions=16,
-		n_vocab=128,
-	)
+    config = MyGPTConfig(
+        n_layers=2,
+        n_heads=2,
+        embedding_size=16,
+        n_positions=16,
+        n_vocab=128,
+    )
 
-	model_a = MyGPT(config)
-	model_b = "Not a ConfiguredModel instance"
+    model_a = MyGPT(config)
+    model_b = "Not a ConfiguredModel instance"
 
-	try:
-		assert_model_cfg_equality(model_a, model_b)
-	except AssertionError as exc:
-		assert str(exc) == "model_b must be a ConfiguredModel"
+    try:
+        assert_model_cfg_equality(model_a, model_b)
+    except AssertionError as exc:
+        assert str(exc) == "model_b must be a ConfiguredModel"

--- a/tests/zanj/test_zanj_torch_cfgmismatch.py
+++ b/tests/zanj/test_zanj_torch_cfgmismatch.py
@@ -1,0 +1,147 @@
+from typing import Any
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+from muutils.json_serialize import (
+    SerializableDataclass,
+    serializable_dataclass,
+    serializable_field,
+)
+from muutils.tensor_utils import compare_state_dicts
+from muutils.zanj import ZANJ
+import torch
+from muutils.zanj.torchutil import ConfiguredModel, set_config_class, ConfigMismatchException, assert_model_cfg_equality
+
+# Assuming required imports and classes are present (including ConfiguredModel, MyGPTConfig, and MyGPT)
+
+
+@serializable_dataclass
+class MyGPTConfig(SerializableDataclass):
+	"""basic test GPT config"""
+
+	n_layers: int
+	n_heads: int
+	embedding_size: int
+	n_positions: int
+	n_vocab: int
+	junk_data: Any = serializable_field(default_factory=dict)
+
+
+@set_config_class(MyGPTConfig)
+class MyGPT(ConfiguredModel[MyGPTConfig]):
+	"""basic "GPT" model"""
+
+	def __init__(self, config: MyGPTConfig):
+		super().__init__(config)
+		self.transformer = torch.nn.Linear(config.embedding_size, config.n_vocab)
+
+	def forward(self, x):
+		return self.transformer(x)
+
+
+def test_config_mismatch_exception_direct():
+	msg = "Configs don't match"
+	diff = {"model_cfg": {"are_weights_processed": {"self": False, "other": True}}}
+
+	exc = ConfigMismatchException(msg, diff)
+	assert exc.diff == diff
+	assert str(exc) == r"Configs don't match: {'model_cfg': {'are_weights_processed': {'self': False, 'other': True}}}"
+
+
+def test_equal_configs():
+	config = MyGPTConfig(
+		n_layers=2,
+		n_heads=2,
+		embedding_size=16,
+		n_positions=16,
+		n_vocab=128,
+		junk_data = {"a": 1, "b": 2},
+	)
+
+	model_a = MyGPT(config)
+	model_b = MyGPT(config)
+
+	assert_model_cfg_equality(model_a, model_b)
+
+def test_unequal_configs():
+	config_a = MyGPTConfig(
+		n_layers=2,
+		n_heads=2,
+		embedding_size=16,
+		n_positions=16,
+		n_vocab=128,
+		junk_data = {"a": 1, "b": 2},
+	)
+	# a different config
+	config_b = MyGPTConfig(
+		n_layers=3,
+		n_heads=2,
+		embedding_size=16,
+		n_positions=16,
+		n_vocab=128,
+		junk_data = {"a": 7, "something": "or other"},
+	)
+
+	model_a = MyGPT(config_a)
+	model_b = MyGPT(config_b)
+
+	try:
+		assert_model_cfg_equality(model_a, model_b)
+	except ConfigMismatchException as exc:
+		assert exc.diff == {
+				"n_layers": {"self": 2, "other": 3},
+				"junk_data": {"self": {"a": 1, "b": 2}, "other": {"a": 7, "something": "or other"}},
+			}
+	else:
+		raise AssertionError("Expected a ConfigMismatchException!")
+
+def test_unequal_configs_2():
+	config_a = MyGPTConfig(
+		n_layers=2,
+		n_heads=2,
+		embedding_size=16,
+		n_positions=16,
+		n_vocab=128,
+		junk_data = {"a": 1, "b": 2},
+	)
+	# a different config
+	config_b = MyGPTConfig(
+		n_layers=3,
+		n_heads=2,
+		embedding_size=16,
+		n_positions=16,
+		n_vocab=128,
+		junk_data = "this isnt even a dict lol",
+	)
+
+	model_a = MyGPT(config_a)
+	model_b = MyGPT(config_b)
+
+	try:
+		assert_model_cfg_equality(model_a, model_b)
+	except ConfigMismatchException as exc:
+		assert exc.diff == {
+				"n_layers": {"self": 2, "other": 3},
+				"junk_data": {"self": {"a": 1, "b": 2}, "other": "this isnt even a dict lol"},
+			}
+	else:
+		raise AssertionError("Expected a ConfigMismatchException!")
+
+def test_incorrect_instance():
+	config = MyGPTConfig(
+		n_layers=2,
+		n_heads=2,
+		embedding_size=16,
+		n_positions=16,
+		n_vocab=128,
+	)
+
+	model_a = MyGPT(config)
+	model_b = "Not a ConfiguredModel instance"
+
+	try:
+		assert_model_cfg_equality(model_a, model_b)
+	except AssertionError as exc:
+		assert str(exc) == "model_b must be a ConfiguredModel"


### PR DESCRIPTION
added `ConfigMismatchException` and tests for it. mainly useful for downstream tests, since `ConfigMismatchException(msg, diff)` lets you access the diff upstream in a `try...except`