### PR TITLE
Migrate utilities from `maze-dataset`

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - "*"
   push:
     branches:
       - main

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ muutils.egg-info/
 
 # setup_build.sh
 
+# pyenv
+.python-version

--- a/muutils/errormode.py
+++ b/muutils/errormode.py
@@ -40,8 +40,10 @@ class ErrorMode(Enum):
         if self is ErrorMode.EXCEPT:
             # except, possibly with a chained exception
             frame: types.FrameType = sys._getframe(1)
-            traceback: types.TracebackType = types.TracebackType(None, frame, frame.f_lasti, frame.f_lineno)
-            
+            traceback: types.TracebackType = types.TracebackType(
+                None, frame, frame.f_lasti, frame.f_lineno
+            )
+
             # Attach the new traceback to the exception and raise it without the internal call stack
             if except_from is not None:
                 raise except_cls(msg).with_traceback(traceback) from except_from
@@ -64,13 +66,22 @@ class ErrorMode(Enum):
                     filename: str,
                     lineno: int,
                     file: typing.Optional[typing.TextIO] = None,
-                    line: typing.Optional[str] = None
+                    line: typing.Optional[str] = None,
                 ) -> None:
                     # Get the frame where process() was called
-                    frame = sys._getframe(3)  # Adjusted to account for the extra function call
+                    frame = sys._getframe(
+                        3
+                    )  # Adjusted to account for the extra function call
                     # Call the original showwarning function
-                    original_showwarning(message, category, frame.f_code.co_filename, frame.f_lineno, file, line)
-                
+                    original_showwarning(
+                        message,
+                        category,
+                        frame.f_code.co_filename,
+                        frame.f_lineno,
+                        file,
+                        line,
+                    )
+
                 try:
                     warnings.showwarning = custom_showwarning
                     warn_func(msg, category=warn_cls)

--- a/muutils/errormode.py
+++ b/muutils/errormode.py
@@ -61,7 +61,7 @@ class ErrorMode(Enum):
                 original_showwarning = warnings.showwarning
 
                 def custom_showwarning(
-                    message: str,
+                    message: Warning | str,
                     category: typing.Type[Warning],
                     filename: str,
                     lineno: int,

--- a/muutils/misc.py
+++ b/muutils/misc.py
@@ -444,7 +444,7 @@ def empty_sequence_if_attr_false(
     itr: Iterable[Any],
     attr_owner: Any,
     attr_name: str,
-) -> Iterable[any]:
+) -> Iterable[Any]:
     """Returns `itr` if `attr_owner` has the attribute `attr_name` and it boolean casts to `True`. Returns an empty sequence otherwise.
 
     Particularly useful for optionally inserting delimiters into a sequence depending on an `TokenizerElement` attribute.
@@ -464,7 +464,7 @@ def empty_sequence_if_attr_false(
     return itr if bool(getattr(attr_owner, attr_name, False)) else ()
 
 
-def flatten(it: Iterable[any], levels_to_flatten: int | None = None) -> Generator:
+def flatten(it: Iterable[Any], levels_to_flatten: int | None = None) -> Generator:
     """
     Flattens an arbitrarily nested iterable.
     Flattens all iterable data types except for `str` and `bytes`.
@@ -515,12 +515,11 @@ def get_all_subclasses(class_: type, include_self=False) -> set[type]:
     Since most class hierarchies are small, the inefficiencies of the existing recursive implementation aren't problematic.
     It might be valuable to refactor with memoization if the need arises to use this function on a very large class hierarchy.
     """
-    subs: list[set] = [
+    subs: set[type] = set(flatten(
         get_all_subclasses(sub, include_self=True)
         for sub in class_.__subclasses__()
         if sub is not None
-    ]
-    subs: set = set(flatten(subs))
+    ))
     if include_self:
         subs.add((class_))
     return subs

--- a/muutils/misc.py
+++ b/muutils/misc.py
@@ -516,7 +516,7 @@ def get_all_subclasses(class_: type, include_self=False) -> set[type]:
     I.e., includes subclasses of subclasses, etc.
 
     # Parameters
-    - `include_self`: Whether to include `class_` itself in the returned list
+    - `include_self`: Whether to include `class_` itself in the returned set
     - `class_`: Superclass
 
     # Development
@@ -531,7 +531,7 @@ def get_all_subclasses(class_: type, include_self=False) -> set[type]:
         )
     )
     if include_self:
-        subs.add((class_))
+        subs.add(class_)
     return subs
 
 
@@ -560,8 +560,9 @@ class IsDataclass(Protocol):
 
 
 def get_hashable_eq_attrs(dc: IsDataclass) -> tuple[Any]:
-    """Returns a tuple of all fields used for equality comparison.
-    Essentially used to generate a hashable dataclass representation of a dataclass for equality comparison even if it's not frozen.
+    """Returns a tuple of all fields used for equality comparison, including the type of the dataclass itself.
+    The type is included to preserve the unequal equality behavior of instances of different dataclasses whose fields are identical.
+    Essentially used to generate a hashable dataclass representation for equality comparison even if it's not frozen.
     """
     return *(
         getattr(dc, fld.name)

--- a/muutils/statcounter.py
+++ b/muutils/statcounter.py
@@ -226,8 +226,8 @@ FancyTimeitResult = NamedTuple(
 
 
 def timeit_fancy(
-    cmd: Callable[[], T] | str,
-    setup: str = lambda: None,
+    cmd: Callable[[], T],
+    setup: Union[str, Callable[[], Any]] = lambda: None,
     repeats: int = 5,
     namespace: Union[dict[str, Any], None] = None,
     get_return: bool = True,
@@ -271,7 +271,6 @@ def timeit_fancy(
     times: list[float] = timer.repeat(repeats, 1)
 
     # Optionally capture the return value
-    return_value: T | None = None
     profile: pstats.Stats | None = None
 
     if get_return or do_profiling:
@@ -280,7 +279,7 @@ def timeit_fancy(
             profiler = cProfile.Profile()
             profiler.enable()
 
-        return_value: T = cmd()
+        return_value: T | None = cmd()
 
         if do_profiling:
             profiler.disable()

--- a/muutils/statcounter.py
+++ b/muutils/statcounter.py
@@ -219,8 +219,8 @@ FancyTimeitResult = NamedTuple(
     "FancyTimeitResult",
     [
         ("timings", StatCounter),
-        ("return_value", T | None),
-        ("profile", pstats.Stats | None),
+        ("return_value", Union[T, None]),
+        ("profile", Union[pstats.Stats, None]),
     ],
 )
 
@@ -229,7 +229,7 @@ def timeit_fancy(
     cmd: Callable[[], T] | str,
     setup: str = lambda: None,
     repeats: int = 5,
-    namespace: dict[str, Any] | None = None,
+    namespace: Union[dict[str, Any], None] = None,
     get_return: bool = True,
     do_profiling: bool = False,
 ) -> FancyTimeitResult:

--- a/muutils/statcounter.py
+++ b/muutils/statcounter.py
@@ -2,13 +2,10 @@ from __future__ import annotations
 
 import json
 import math
-import pstats
-import timeit
-import cProfile
 from collections import Counter
 from functools import cached_property
 from itertools import chain
-from typing import Callable, Optional, Sequence, Union, TypeVar, NamedTuple, Any
+from typing import Callable, Optional, Sequence, Union
 
 
 # _GeneralArray = Union[np.ndarray, "torch.Tensor"]
@@ -211,86 +208,3 @@ class StatCounter(Counter):
     ) -> "StatCounter":
         """calls `map_func` on each element of `universal_flatten(arr)`"""
         return cls([map_func(x) for x in universal_flatten(arr)])
-
-
-T = TypeVar("T")
-
-FancyTimeitResult = NamedTuple(
-    "FancyTimeitResult",
-    [
-        ("timings", StatCounter),
-        ("return_value", Union[T, None]),
-        ("profile", Union[pstats.Stats, None]),
-    ],
-)
-
-
-def timeit_fancy(
-    cmd: Callable[[], T],
-    setup: Union[str, Callable[[], Any]] = lambda: None,
-    repeats: int = 5,
-    namespace: Union[dict[str, Any], None] = None,
-    get_return: bool = True,
-    do_profiling: bool = False,
-) -> FancyTimeitResult:
-    """
-    Wrapper for `timeit` to get the fastest run of a callable with more customization options.
-
-    Approximates the functionality of the %timeit magic or command line interface in a Python callable.
-
-    # Parameters
-    - `cmd: Callable[[], T] | str`
-        The callable to time. If a string, it will be passed to `timeit.Timer` as the `stmt` argument.
-    - `setup: str`
-        The setup code to run before `cmd`. If a string, it will be passed to `timeit.Timer` as the `setup` argument.
-    - `repeats: int`
-        The number of times to run `cmd` to get a reliable measurement.
-    - `namespace: dict[str, Any]`
-        Passed to `timeit.Timer` constructor.
-        If `cmd` or `setup` use local or global variables, they must be passed here. See `timeit` documentation for details.
-    - `get_return: bool`
-        Whether to pass the value returned from `cmd`. If True, the return value will be appended in a tuple with execution time.
-        This is for speed and convenience so that `cmd` doesn't need to be run again in the calling scope if the return values are needed.
-        (default: `False`)
-    - `do_profiling: bool`
-        Whether to return a `pstats.Stats` object in addition to the time and return value.
-        (default: `False`)
-
-    # Returns
-    `FancyTimeitResult`, which is a NamedTuple with the following fields:
-    - `time: float`
-        The time in seconds it took to run `cmd` the minimum number of times to get a reliable measurement.
-    - `return_value: T|None`
-        The return value of `cmd` if `get_return` is `True`, otherwise `None`.
-    - `profile: pstats.Stats|None`
-        A `pstats.Stats` object if `do_profiling` is `True`, otherwise `None`.
-    """
-    timer: timeit.Timer = timeit.Timer(cmd, setup, globals=namespace)
-
-    # Perform the timing
-    times: list[float] = timer.repeat(repeats, 1)
-
-    # Optionally capture the return value
-    profile: pstats.Stats | None = None
-
-    if get_return or do_profiling:
-        # Optionally perform profiling
-        if do_profiling:
-            profiler = cProfile.Profile()
-            profiler.enable()
-
-        return_value: T | None = cmd()
-
-        if do_profiling:
-            profiler.disable()
-            profile = pstats.Stats(profiler).strip_dirs().sort_stats("cumulative")
-
-    # reset the return value if it wasn't requested
-    if not get_return:
-        return_value = None
-
-    return FancyTimeitResult(
-        timings=StatCounter(times),
-        return_value=return_value,
-        profile=profile,
-    )

--- a/muutils/statcounter.py
+++ b/muutils/statcounter.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 import json
 import math
+import pstats
+import timeit
+import cProfile
 from collections import Counter
 from functools import cached_property
 from itertools import chain
-from typing import Callable, Optional, Sequence, Union
+from typing import Callable, Optional, Sequence, Union, TypeVar, NamedTuple, Any
+
 
 # _GeneralArray = Union[np.ndarray, "torch.Tensor"]
 NumericSequence = Sequence[Union[float, int]]
@@ -207,3 +211,87 @@ class StatCounter(Counter):
     ) -> "StatCounter":
         """calls `map_func` on each element of `universal_flatten(arr)`"""
         return cls([map_func(x) for x in universal_flatten(arr)])
+
+
+T = TypeVar("T")
+
+FancyTimeitResult = NamedTuple(
+    "FancyTimeitResult",
+    [
+        ("timings", StatCounter),
+        ("return_value", T | None),
+        ("profile", pstats.Stats | None),
+    ],
+)
+
+
+def timeit_fancy(
+    cmd: Callable[[], T] | str,
+    setup: str = lambda: None,
+    repeats: int = 5,
+    namespace: dict[str, Any] | None = None,
+    get_return: bool = True,
+    do_profiling: bool = False,
+) -> FancyTimeitResult:
+    """
+    Wrapper for `timeit` to get the fastest run of a callable with more customization options.
+
+    Approximates the functionality of the %timeit magic or command line interface in a Python callable.
+
+    # Parameters
+    - `cmd: Callable[[], T] | str`
+        The callable to time. If a string, it will be passed to `timeit.Timer` as the `stmt` argument.
+    - `setup: str`
+        The setup code to run before `cmd`. If a string, it will be passed to `timeit.Timer` as the `setup` argument.
+    - `repeats: int`
+        The number of times to run `cmd` to get a reliable measurement.
+    - `namespace: dict[str, Any]`
+        Passed to `timeit.Timer` constructor.
+        If `cmd` or `setup` use local or global variables, they must be passed here. See `timeit` documentation for details.
+    - `get_return: bool`
+        Whether to pass the value returned from `cmd`. If True, the return value will be appended in a tuple with execution time.
+        This is for speed and convenience so that `cmd` doesn't need to be run again in the calling scope if the return values are needed.
+        (default: `False`)
+    - `do_profiling: bool`
+        Whether to return a `pstats.Stats` object in addition to the time and return value.
+        (default: `False`)
+
+    # Returns
+    `FancyTimeitResult`, which is a NamedTuple with the following fields:
+    - `time: float`
+        The time in seconds it took to run `cmd` the minimum number of times to get a reliable measurement.
+    - `return_value: T|None`
+        The return value of `cmd` if `get_return` is `True`, otherwise `None`.
+    - `profile: pstats.Stats|None`
+        A `pstats.Stats` object if `do_profiling` is `True`, otherwise `None`.
+    """
+    timer: timeit.Timer = timeit.Timer(cmd, setup, globals=namespace)
+
+    # Perform the timing
+    times: list[float] = timer.repeat(repeats, 1)
+
+    # Optionally capture the return value
+    return_value: T | None = None
+    profile: pstats.Stats | None = None
+
+    if get_return or do_profiling:
+        # Optionally perform profiling
+        if do_profiling:
+            profiler = cProfile.Profile()
+            profiler.enable()
+
+        return_value: T = cmd()
+
+        if do_profiling:
+            profiler.disable()
+            profile = pstats.Stats(profiler).strip_dirs().sort_stats("cumulative")
+
+    # reset the return value if it wasn't requested
+    if not get_return:
+        return_value = None
+
+    return FancyTimeitResult(
+        timings=StatCounter(times),
+        return_value=return_value,
+        profile=profile,
+    )

--- a/muutils/timeit_fancy.py
+++ b/muutils/timeit_fancy.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import pstats
+import timeit
+import cProfile
+from typing import Callable, Union, TypeVar, NamedTuple, Any
+
+from muutils.statcounter import StatCounter
+
+T = TypeVar("T")
+
+FancyTimeitResult = NamedTuple(
+    "FancyTimeitResult",
+    [
+        ("timings", StatCounter),
+        ("return_value", Union[T, None]),
+        ("profile", Union[pstats.Stats, None]),
+    ],
+)
+
+
+def timeit_fancy(
+    cmd: Callable[[], T],
+    setup: Union[str, Callable[[], Any]] = lambda: None,
+    repeats: int = 5,
+    namespace: Union[dict[str, Any], None] = None,
+    get_return: bool = True,
+    do_profiling: bool = False,
+) -> FancyTimeitResult:
+    """
+    Wrapper for `timeit` to get the fastest run of a callable with more customization options.
+
+    Approximates the functionality of the %timeit magic or command line interface in a Python callable.
+
+    # Parameters
+    - `cmd: Callable[[], T] | str`
+        The callable to time. If a string, it will be passed to `timeit.Timer` as the `stmt` argument.
+    - `setup: str`
+        The setup code to run before `cmd`. If a string, it will be passed to `timeit.Timer` as the `setup` argument.
+    - `repeats: int`
+        The number of times to run `cmd` to get a reliable measurement.
+    - `namespace: dict[str, Any]`
+        Passed to `timeit.Timer` constructor.
+        If `cmd` or `setup` use local or global variables, they must be passed here. See `timeit` documentation for details.
+    - `get_return: bool`
+        Whether to pass the value returned from `cmd`. If True, the return value will be appended in a tuple with execution time.
+        This is for speed and convenience so that `cmd` doesn't need to be run again in the calling scope if the return values are needed.
+        (default: `False`)
+    - `do_profiling: bool`
+        Whether to return a `pstats.Stats` object in addition to the time and return value.
+        (default: `False`)
+
+    # Returns
+    `FancyTimeitResult`, which is a NamedTuple with the following fields:
+    - `time: float`
+        The time in seconds it took to run `cmd` the minimum number of times to get a reliable measurement.
+    - `return_value: T|None`
+        The return value of `cmd` if `get_return` is `True`, otherwise `None`.
+    - `profile: pstats.Stats|None`
+        A `pstats.Stats` object if `do_profiling` is `True`, otherwise `None`.
+    """
+    timer: timeit.Timer = timeit.Timer(cmd, setup, globals=namespace)
+
+    # Perform the timing
+    times: list[float] = timer.repeat(repeats, 1)
+
+    # Optionally capture the return value
+    profile: pstats.Stats | None = None
+
+    if get_return or do_profiling:
+        # Optionally perform profiling
+        if do_profiling:
+            profiler = cProfile.Profile()
+            profiler.enable()
+
+        return_value: T | None = cmd()
+
+        if do_profiling:
+            profiler.disable()
+            profile = pstats.Stats(profiler).strip_dirs().sort_stats("cumulative")
+
+    # reset the return value if it wasn't requested
+    if not get_return:
+        return_value = None
+
+    return FancyTimeitResult(
+        timings=StatCounter(times),
+        return_value=return_value,
+        profile=profile,
+    )

--- a/muutils/timeit_fancy.py
+++ b/muutils/timeit_fancy.py
@@ -4,6 +4,7 @@ import pstats
 import timeit
 import cProfile
 from typing import Callable, Union, TypeVar, NamedTuple, Any
+import warnings
 
 from muutils.statcounter import StatCounter
 
@@ -67,13 +68,19 @@ def timeit_fancy(
     # Optionally capture the return value
     profile: pstats.Stats | None = None
 
+    return_value: T | None = None
     if get_return or do_profiling:
         # Optionally perform profiling
         if do_profiling:
             profiler = cProfile.Profile()
             profiler.enable()
 
-        return_value: T | None = cmd()
+        try:
+            return_value = cmd()
+        except TypeError as e:
+            warnings.warn(
+                f"Failed to get return value from `cmd` due to error (probably passing a string). will return `return_value=None`\n{e}",
+            )
 
         if do_profiling:
             profiler.disable()

--- a/poetry.lock
+++ b/poetry.lock
@@ -1191,6 +1191,7 @@ description = "Nvidia JIT LTO Library"
 optional = true
 python-versions = ">=3"
 files = [
+    {file = "nvidia_nvjitlink_cu12-12.5.40-py3-none-manylinux2014_aarch64.whl", hash = "sha256:004186d5ea6a57758fd6d57052a123c73a4815adf365eb8dd6a85c9eaa7535ff"},
     {file = "nvidia_nvjitlink_cu12-12.5.40-py3-none-manylinux2014_x86_64.whl", hash = "sha256:d9714f27c1d0f0895cd8915c07a87a1d0029a0aa36acaf9156952ec2a8a12189"},
     {file = "nvidia_nvjitlink_cu12-12.5.40-py3-none-win_amd64.whl", hash = "sha256:c3401dc8543b52d3a8158007a0c1ab4e9c768fcbd24153a48c86972102197ddd"},
 ]
@@ -1537,6 +1538,7 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -1920,6 +1922,7 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 
 [extras]
 array = ["jaxtyping", "numpy", "numpy", "torch"]
+array-nb-zanj = ["ipython", "jaxtyping", "numpy", "numpy", "torch", "zanj"]
 array-no-torch = ["jaxtyping", "numpy", "numpy"]
 notebook = ["ipython"]
 zanj = ["zanj"]
@@ -1927,4 +1930,4 @@ zanj = ["zanj"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "c19aedfdf3ebb7bddf7e11f9e1dffbba4e23ada805b9fe46a70982999f1eee41"
+content-hash = "4aa4a7a375b1b47a8cfd27756a5e660fe02f64a123c590c6243dea05f54bc783"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ pycln = "^2.1.3"
 ruff = "^0.4.8"
 
 [tool.poetry.extras]
+array_nb_zanj = ["numpy", "torch", "jaxtyping", "ipython", "zanj"]
 array = ["numpy", "torch", "jaxtyping"]
 # special group for CI, where we install cpu torch separately
 array_no_torch = ["numpy", "jaxtyping"]

--- a/tests/unit/misc/test_misc.py
+++ b/tests/unit/misc/test_misc.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Iterable
+from typing import Iterable, Any, Type, Union
 from dataclasses import dataclass
 import abc
 import pytest
@@ -272,7 +272,7 @@ def test_get_all_subclasses_include_self():
         )
     ],
 )
-def test_flatten(deep: Iterable[any], flat: Iterable[any], depth: int | None):
+def test_flatten(deep: Iterable[Any], flat: Iterable[Any], depth: Union[int, None]):
     assert list(flatten(deep, depth)) == flat
 
 
@@ -348,7 +348,7 @@ class DC7(abc.ABC):
     x: bool
 
     @abc.abstractmethod
-    def foo():
+    def foo(self):
         pass
 
 
@@ -356,7 +356,7 @@ class DC7(abc.ABC):
 class DC8(DC7):
     x: bool = False
 
-    def foo():
+    def foo(self):
         pass
 
 
@@ -364,7 +364,7 @@ class DC8(DC7):
 class DC9(DC7):
     y: bool = True
 
-    def foo():
+    def foo(self):
         pass
 
 
@@ -414,11 +414,11 @@ class DC9(DC7):
                 ),
                 (
                     [
-                        DC3(False),
-                        DC3(False),
+                        DC3(DC2(False)),
+                        DC3(DC2(False)),
                     ],
                     [
-                        DC3(False),
+                        DC3(DC2(False)),
                     ],
                     True,
                 ),
@@ -431,7 +431,7 @@ class DC9(DC7):
 def test_dataclass_set_equals(
     coll1: Iterable[IsDataclass],
     coll2: Iterable[IsDataclass],
-    result: bool | type[Exception],
+    result: Union[bool, Type[Exception]],
 ):
     if isinstance(result, type) and issubclass(result, Exception):
         with pytest.raises(result):
@@ -461,7 +461,7 @@ def test_dataclass_set_equals(
     ],
 )
 def test_isinstance_by_type_name(
-    o: object, type_name: str, result: bool | type[Exception]
+    o: object, type_name: str, result: Union[bool, Type[Exception]]
 ):
     if isinstance(result, type) and issubclass(result, Exception):
         with pytest.raises(result):

--- a/tests/unit/misc/test_misc.py
+++ b/tests/unit/misc/test_misc.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
+from typing import Iterable
 
 import pytest
+from pytest import mark, param
 
 from muutils.misc import (
     dict_to_filename,
@@ -11,6 +13,8 @@ from muutils.misc import (
     sanitize_identifier,
     sanitize_name,
     stable_hash,
+    flatten,
+    get_all_subclasses,
 )
 
 
@@ -183,3 +187,118 @@ def test_list_join():
         1
     ], "Single item list should remain unchanged"
     assert list_join([], lambda: "x") == [], "Empty list should remain unchanged"
+
+
+# Testing the flatten function
+def test_flatten_full_flattening():
+    assert list(flatten([1, [2, [3, 4]], 5])) == [1, 2, 3, 4, 5]
+    assert list(flatten([1, [2, [3, [4, [5]]]]])) == [1, 2, 3, 4, 5]
+    assert list(flatten([])) == []
+
+
+def test_flatten_partial_flattening():
+    assert list(flatten([1, [2, [3, 4]], 5], levels_to_flatten=1)) == [1, 2, [3, 4], 5]
+    assert list(flatten([1, [2, [3, [4, [5]]]]], levels_to_flatten=2)) == [
+        1,
+        2,
+        3,
+        [4, [5]],
+    ]
+
+
+def test_flatten_with_non_iterables():
+    assert list(flatten([1, 2, 3])) == [1, 2, 3]
+    assert list(flatten([1, "abc", 2, [3, 4], 5])) == [1, "abc", 2, 3, 4, 5]
+
+
+# Testing the get_all_subclasses function
+class A:
+    pass
+
+
+class B(A):
+    pass
+
+
+class C(B):
+    pass
+
+
+def test_get_all_subclasses():
+    assert get_all_subclasses(A) == {B, C}
+    assert get_all_subclasses(B) == {C}
+    assert get_all_subclasses(C) == set()
+
+
+def test_get_all_subclasses_include_self():
+    assert get_all_subclasses(A, include_self=True) == {A, B, C}
+    assert get_all_subclasses(B, include_self=True) == {B, C}
+    assert get_all_subclasses(C, include_self=True) == {C}
+
+
+@mark.parametrize(
+    "deep, flat, depth",
+    [
+        param(
+            iter_tuple[0],
+            iter_tuple[1],
+            iter_tuple[2],
+            id=f"{i}",
+        )
+        for i, iter_tuple in enumerate(
+            [
+                ([1, 2, 3, 4], [1, 2, 3, 4], None),
+                ((1, 2, 3, 4), [1, 2, 3, 4], None),
+                ((j for j in [1, 2, 3, 4]), [1, 2, 3, 4], None),
+                (["a", "b", "c", "d"], ["a", "b", "c", "d"], None),
+                ("funky duck", [c for c in "funky duck"], None),
+                (["funky", "duck"], ["funky", "duck"], None),
+                (b"funky duck", [b for b in b"funky duck"], None),
+                ([b"funky", b"duck"], [b"funky", b"duck"], None),
+                ([[1, 2, 3, 4]], [1, 2, 3, 4], None),
+                ([[[[1, 2, 3, 4]]]], [1, 2, 3, 4], None),
+                ([[[[1], 2], 3], 4], [1, 2, 3, 4], None),
+                ([[1, 2], [[3]], (4,)], [1, 2, 3, 4], None),
+                ([[[1, 2, 3, 4]]], [[1, 2, 3, 4]], 1),
+                ([[[1, 2, 3, 4]]], [1, 2, 3, 4], 2),
+                ([[1, 2], [[3]], (4,)], [1, 2, [3], 4], 1),
+                ([[1, 2], [(3,)], (4,)], [1, 2, (3,), 4], 1),
+                ([[[[1], 2], 3], 4], [[1], 2, 3, 4], 2),
+            ]
+        )
+    ],
+)
+def test_flatten(deep: Iterable[any], flat: Iterable[any], depth: int | None):
+    assert list(flatten(deep, depth)) == flat
+
+
+def test_get_all_subclasses2():
+    class A:
+        pass
+
+    class B(A):
+        pass
+
+    class C(A):
+        pass
+
+    class D(B, C):
+        pass
+
+    class E(B):
+        pass
+
+    class F(D):
+        pass
+
+    class Z:
+        pass
+
+    assert get_all_subclasses(A) == {B, C, D, E, F}
+    assert get_all_subclasses(A, include_self=True) == {A, B, C, D, E, F}
+    assert get_all_subclasses(B) == {D, E, F}
+    assert get_all_subclasses(C) == {D, F}
+    assert get_all_subclasses(D) == {F}
+    assert get_all_subclasses(D, include_self=True) == {D, F}
+    assert get_all_subclasses(Z) == set()
+    assert get_all_subclasses(Z, include_self=True) == {Z}

--- a/tests/unit/test_timeit_fancy.py
+++ b/tests/unit/test_timeit_fancy.py
@@ -1,0 +1,87 @@
+import pytest
+from muutils.statcounter import StatCounter
+from typing import Callable, Any
+import pstats
+
+# Assuming the timeit_fancy function and FancyTimeitResult are imported from the correct module
+from muutils.timeit_fancy import timeit_fancy, FancyTimeitResult
+
+
+def test_timeit_fancy_basic():
+    def simple_function():
+        return sum(range(1000))
+
+    result = timeit_fancy(simple_function)
+
+    assert isinstance(result, FancyTimeitResult)
+    assert isinstance(result.timings, StatCounter)
+    assert result.return_value is None
+    assert result.profile is None
+    assert all(t > 0 for t in result.timings.values())
+
+
+def test_timeit_fancy_with_return():
+    def simple_function():
+        return sum(range(1000))
+
+    result = timeit_fancy(simple_function, get_return=True)
+
+    assert isinstance(result, FancyTimeitResult)
+    assert isinstance(result.timings, StatCounter)
+    assert result.return_value == 499500
+    assert result.profile is None
+    assert all(t > 0 for t in result.timings.values())
+
+
+def test_timeit_fancy_with_profiling():
+    def simple_function():
+        return sum(range(1000))
+
+    result = timeit_fancy(simple_function, do_profiling=True)
+
+    assert isinstance(result, FancyTimeitResult)
+    assert isinstance(result.timings, StatCounter)
+    assert result.return_value is None
+    assert isinstance(result.profile, pstats.Stats)
+    assert all(t > 0 for t in result.timings.values())
+
+
+def test_timeit_fancy_with_setup():
+    setup = "x = 10"
+
+    def simple_function():
+        # x is defined in the setup
+        return x * 2  # noqa: F821
+
+    result = timeit_fancy(simple_function, setup=setup, namespace={"x": 10})
+
+    assert isinstance(result, FancyTimeitResult)
+    assert isinstance(result.timings, StatCounter)
+    assert result.return_value is None
+    assert result.profile is None
+    assert all(t > 0 for t in result.timings.values())
+
+
+def test_timeit_fancy_with_repeats():
+    def simple_function():
+        return sum(range(100))
+
+    result = timeit_fancy(simple_function, repeats=10)
+
+    assert isinstance(result, FancyTimeitResult)
+    assert isinstance(result.timings, StatCounter)
+    assert len(result.timings) == 10
+    assert result.return_value is None
+    assert result.profile is None
+    assert all(t > 0 for t in result.timings.values())
+
+
+@pytest.mark.parametrize("cmd", [lambda: sum(range(100)), "sum(range(100))"])
+def test_timeit_fancy_with_different_cmd_types(cmd: Callable[[], Any] | str):
+    result = timeit_fancy(cmd)
+
+    assert isinstance(result, FancyTimeitResult)
+    assert isinstance(result.timings, StatCounter)
+    assert result.return_value is None
+    assert result.profile is None
+    assert all(t > 0 for t in result.timings.values())


### PR DESCRIPTION
Migrating the following utilities from the `maze-dataset` repo. Some of these are from the `tokenizer-overhaul-step2` branch and were never merged to the main branch. 
- `get_all_subclasses`
- `flatten`
- `timeitfancy`
- `empty_sequence_if_attr_false`
- `is_abstract`
- `get_hashable_eq_attrs`
- `dataclass_set_equals`
- `isinstance_by_type_name`