### PR TITLE
Fix `dc_eq` behavior for distinct classes with identical fields

### DIFF
--- a/muutils/json_serialize/util.py
+++ b/muutils/json_serialize/util.py
@@ -246,7 +246,6 @@ def dc_eq(
                 )
         return False
 
-
     return all(
         array_safe_eq(getattr(dc1, fld.name), getattr(dc2, fld.name))
         for fld in dataclasses.fields(dc1)

--- a/muutils/json_serialize/util.py
+++ b/muutils/json_serialize/util.py
@@ -235,19 +235,17 @@ def dc_eq(
             raise TypeError(
                 f"Cannot compare dataclasses of different classes: `{dc1.__class__}` and `{dc2.__class__}`"
             )
-        else:
+        if except_when_field_mismatch:
             dc1_fields: set = set([fld.name for fld in dataclasses.fields(dc1)])
             dc2_fields: set = set([fld.name for fld in dataclasses.fields(dc2)])
             fields_match: bool = set(dc1_fields) == set(dc2_fields)
-
             if not fields_match:
                 # if the fields match, keep going
-                if except_when_field_mismatch:
-                    raise AttributeError(
-                        f"dataclasses {dc1} and {dc2} have different fields: `{dc1_fields}` and `{dc2_fields}`"
-                    )
-                else:
-                    return False
+                raise AttributeError(
+                    f"dataclasses {dc1} and {dc2} have different fields: `{dc1_fields}` and `{dc2_fields}`"
+                )
+        return False
+
 
     return all(
         array_safe_eq(getattr(dc1, fld.name), getattr(dc2, fld.name))

--- a/tests/unit/json_serialize/serializable_dataclass/test_helpers.py
+++ b/tests/unit/json_serialize/serializable_dataclass/test_helpers.py
@@ -97,3 +97,92 @@ def test_dc_eq_case3():
     )
 
     assert not dc_eq(instance1, instance2)
+
+
+def test_dc_eq_case4():
+    @dataclass(eq=False)
+    class TestClass:
+        a: int
+        b: np.ndarray
+        c: torch.Tensor
+        e: list[int]
+        f: dict[str, int]
+
+        
+    @dataclass(eq=False)
+    class TestClass2:
+        a: int
+        b: np.ndarray
+        c: torch.Tensor
+        e: list[int]
+        f: dict[str, int]
+
+    instance1 = TestClass(
+        a=1,
+        b=np.array([1, 2, 3]),
+        c=torch.tensor([1, 2, 3]),
+        e=[1, 2, 3],
+        f={"key1": 1, "key2": 2},
+    )
+
+    instance2 = TestClass2(
+        a=1,
+        b=np.array([1, 2, 3]),
+        c=torch.tensor([1, 2, 3]),
+        e=[1, 2, 3],
+        f={"key1": 1, "key2": 2},
+    )
+
+    assert not dc_eq(instance1, instance2)
+
+
+def test_dc_eq_case5():
+    @dataclass(eq=False)
+    class TestClass:
+        a: int
+
+        
+    @dataclass(eq=False)
+    class TestClass2:
+        a: int
+
+    instance1 = TestClass(
+        a=1
+    )
+
+    instance2 = TestClass2(
+        a=1
+    )
+
+    assert not dc_eq(instance1, instance2)
+
+
+
+def test_dc_eq_case6():
+    @dataclass(eq=False)
+    class TestClass: pass
+
+        
+    @dataclass(eq=False)
+    class TestClass2: pass
+
+    instance1 = TestClass()
+
+    instance2 = TestClass2()
+
+    assert not dc_eq(instance1, instance2)
+
+
+def test_dc_eq_case7():
+    @dataclass
+    class TestClass: pass
+
+        
+    @dataclass
+    class TestClass2: pass
+
+    instance1 = TestClass()
+
+    instance2 = TestClass2()
+
+    assert not dc_eq(instance1, instance2)

--- a/tests/unit/json_serialize/serializable_dataclass/test_helpers.py
+++ b/tests/unit/json_serialize/serializable_dataclass/test_helpers.py
@@ -108,7 +108,6 @@ def test_dc_eq_case4():
         e: list[int]
         f: dict[str, int]
 
-        
     @dataclass(eq=False)
     class TestClass2:
         a: int
@@ -141,30 +140,25 @@ def test_dc_eq_case5():
     class TestClass:
         a: int
 
-        
     @dataclass(eq=False)
     class TestClass2:
         a: int
 
-    instance1 = TestClass(
-        a=1
-    )
+    instance1 = TestClass(a=1)
 
-    instance2 = TestClass2(
-        a=1
-    )
+    instance2 = TestClass2(a=1)
 
     assert not dc_eq(instance1, instance2)
 
 
-
 def test_dc_eq_case6():
     @dataclass(eq=False)
-    class TestClass: pass
+    class TestClass:
+        pass
 
-        
     @dataclass(eq=False)
-    class TestClass2: pass
+    class TestClass2:
+        pass
 
     instance1 = TestClass()
 
@@ -175,11 +169,12 @@ def test_dc_eq_case6():
 
 def test_dc_eq_case7():
     @dataclass
-    class TestClass: pass
+    class TestClass:
+        pass
 
-        
     @dataclass
-    class TestClass2: pass
+    class TestClass2:
+        pass
 
     instance1 = TestClass()
 


### PR DESCRIPTION
See #57 